### PR TITLE
modifies tilt extension to support different grafana images

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -17,6 +17,7 @@ grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version=
         grafana_image  : The grafana image you want to use (i.e. grafana/grafana-enterprise). Defaults to 'grafana/grafana'
         grafana_version: The image tag for the version of grafana you want to use. Defaults to 'latest'
         namespace      : The Kubernetes namespace to deploy to. Defaults to 'default'
+        license        : The Grafana license key
         deps           : A list of Tilt resources Grafana should wait for
         extra_env      : A dict of env vars to pass to Grafana
 

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -14,7 +14,7 @@ grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version=
     Args:
         context        : The Docker context directory that is the root of the Dockerfile. Typically the 'plugin' directory
         plugin_files   : A path, or list of paths to the 'plugin.json' file for the plugin(s) you are running
-        grafana_image  : The grafana image you want to use (i.e. grafana/grafana-enterprise). Defaults to 'grafana/grafana'
+        grafana_image  : The grafana image you want to use. Defaults to 'grafana/grafana'
         grafana_version: The image tag for the version of grafana you want to use. Defaults to 'latest'
         namespace      : The Kubernetes namespace to deploy to. Defaults to 'default'
         license        : The Grafana license key

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -12,14 +12,14 @@ grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version=
     """Deploys one or more plugin(s) in Grafana using the Helm Chart.
 
     Args:
-        context        : The Docker context directory that is the root of the Dockerfile. Typically the 'plugin' directory
-        plugin_files   : A path, or list of paths to the 'plugin.json' file for the plugin(s) you are running
-        grafana_image  : The grafana image you want to use. Defaults to 'grafana/grafana'
-        grafana_version: The image tag for the version of grafana you want to use. Defaults to 'latest'
-        namespace      : The Kubernetes namespace to deploy to. Defaults to 'default'
-        license        : The Grafana license key
-        deps           : A list of Tilt resources Grafana should wait for
-        extra_env      : A dict of env vars to pass to Grafana
+        context          : The Docker context directory that is the root of the Dockerfile. Typically the 'plugin' directory
+        plugin_files     : A path, or list of paths to the 'plugin.json' file for the plugin(s) you are running
+        grafana_image    : The grafana image you want to use. Defaults to 'grafana/grafana'
+        grafana_version  : The image tag for the version of grafana you want to use. Defaults to 'latest'
+        namespace        : The Kubernetes namespace to deploy to. Defaults to 'default'
+        deps             : A list of Tilt resources Grafana should wait for
+        extra_env        : A dict of env vars to pass to Grafana
+        extra_grafana_ini: A dict of key value pairs to configure the grafana.ini file
 
     Returns:
       Nothing

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -8,7 +8,7 @@ Default Grafana helm values are in `grafana-values.yaml`.
 
 Usage is:
 ```
-grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version='latest', namespace='grafana', deps=[], extra_env={}):
+grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version='latest', namespace='grafana', license='', deps=[], extra_env={}):
     """Deploys one or more plugin(s) in Grafana using the Helm Chart.
 
     Args:

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -8,12 +8,13 @@ Default Grafana helm values are in `grafana-values.yaml`.
 
 Usage is:
 ```
-grafana(context, plugin_files, grafana_version='latest', namespace='grafana', deps=[], extra_env={}):
+grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version='latest', namespace='grafana', deps=[], extra_env={}):
     """Deploys one or more plugin(s) in Grafana using the Helm Chart.
 
     Args:
         context        : The Docker context directory that is the root of the Dockerfile. Typically the 'plugin' directory
         plugin_files   : A path, or list of paths to the 'plugin.json' file for the plugin(s) you are running
+        grafana_image  : The grafana image you want to use (i.e. grafana/grafana-enterprise). Defaults to 'grafana/grafana'
         grafana_version: The image tag for the version of grafana you want to use. Defaults to 'latest'
         namespace      : The Kubernetes namespace to deploy to. Defaults to 'default'
         deps           : A list of Tilt resources Grafana should wait for

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -138,9 +138,10 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
     chart_values['image']['repository'] = image_repository
     chart_values['image']['tag'] = image_tag
 
-    # Sets the Grafana Enterprise License Text
+    # Sets the Grafana Enterprise License Text and enables the accessControlOnCall feature flag
     chart_values['grafana.ini']['enterprise'] = {}
     chart_values['grafana.ini']['enterprise']['license_text'] = license
+    chart_values['grafana.ini']['feature_toggles']['enable'] = 'accessControlOnCall'
 
     # The assumption is that the Tiltfiles in the plugin repos will create the configmaps
     # with the name <plugin_id>-provisioning

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -12,8 +12,8 @@ load('ext://local_output', 'local_output')
 # This will generate a Dockerfile with COPY statements for each plugin that has been checked out
 def grafana_dockerfile_contents(context_dir, configs, grafana_image, grafana_version):
     dockerfile="""
-    FROM %s:latest
-    """ % grafana_image
+    FROM %s:%s
+    """ % (grafana_image, grafana_version)
 
     for repo, config in configs.items():
         # TODO the pathing is wonky

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -72,15 +72,16 @@ def get_or_create(dict, key):
     return dict[key]
 
 
-def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version='latest', namespace='grafana', deps=[], extra_env={}):
+def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version='latest', namespace='grafana', license='', deps=[], extra_env={}):
     """Deploys one or more plugin(s) in Grafana using the Helm Chart.
 
     Args:
         context        : The Docker context directory that is the root of the Dockerfile. Typically the 'plugin' directory
         plugin_files   : A path, or list of paths to the 'plugin.json' file for the plugin(s) you are running
-        grafana_image  : The grafana image you want to use (i.e. grafana/grafana-enterprise). Defaults to 'grafana/grafana'
+        grafana_image  : The grafana image you want to use. Defaults to 'grafana/grafana'
         grafana_version: The image tag for the version of grafana you want to use. Defaults to 'latest'
         namespace      : The Kubernetes namespace to deploy to. Defaults to 'default'
+        license        : The Grafana license key. 
         deps           : A list of Tilt resources Grafana should wait for
         extra_env      : A dict of env vars to pass to Grafana
 
@@ -136,6 +137,10 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
     chart_values['image'] = {}
     chart_values['image']['repository'] = image_repository
     chart_values['image']['tag'] = image_tag
+
+    # Sets the Grafana Enterprise License
+    chart_values['grafana.ini']['enterprise'] = {}
+    chart_values['grafana.ini']['enterprise']['license_text'] = license
 
     # The assumption is that the Tiltfiles in the plugin repos will create the configmaps
     # with the name <plugin_id>-provisioning

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -10,10 +10,10 @@ load('ext://local_output', 'local_output')
 
 
 # This will generate a Dockerfile with COPY statements for each plugin that has been checked out
-def grafana_dockerfile_contents(context_dir, configs, grafana_version):
+def grafana_dockerfile_contents(context_dir, configs, grafana_image, grafana_version):
     dockerfile="""
-    FROM grafana/grafana:%s
-    """ % grafana_version
+    FROM %s:latest
+    """ % grafana_image
 
     for repo, config in configs.items():
         # TODO the pathing is wonky
@@ -102,7 +102,7 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
     # TODO: Make this configurable
     image_tag = 'ops-devenv'
     docker_build("%s:%s" % (image_repository, image_tag), 
-                dockerfile_contents = grafana_dockerfile_contents(context, plugins, grafana_version),
+                dockerfile_contents = grafana_dockerfile_contents(context, plugins, grafana_image, grafana_version),
                 context             = context,
                 only                = [os.path.relpath(os.path.abspath( context + '/' + config.plugin_dist_dir), os.path.abspath(context))
                                       for (_, config) in plugins.items()],
@@ -177,7 +177,7 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
     # Deploy the chart
     helm_resource(
         'grafana',
-        image=image_respository,
+        'grafana/grafana',
         namespace=namespace,
         image_deps=[image_repository + ':' + image_tag],
         image_keys=[('image.registry', 'image.repository', 'image.tag')],

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -138,10 +138,9 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
     chart_values['image']['repository'] = image_repository
     chart_values['image']['tag'] = image_tag
 
-    # Sets the Grafana Enterprise License Text and enables the accessControlOnCall feature flag
+    # Sets the Grafana Enterprise License Text
     chart_values['grafana.ini']['enterprise'] = {}
     chart_values['grafana.ini']['enterprise']['license_text'] = license
-    chart_values['grafana.ini']['feature_toggles']['enable'] = 'accessControlOnCall'
 
     # The assumption is that the Tiltfiles in the plugin repos will create the configmaps
     # with the name <plugin_id>-provisioning

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -72,12 +72,13 @@ def get_or_create(dict, key):
     return dict[key]
 
 
-def grafana(context, plugin_files, grafana_version='latest', namespace='grafana', deps=[], extra_env={}):
+def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version='latest', namespace='grafana', deps=[], extra_env={}):
     """Deploys one or more plugin(s) in Grafana using the Helm Chart.
 
     Args:
         context        : The Docker context directory that is the root of the Dockerfile. Typically the 'plugin' directory
         plugin_files   : A path, or list of paths to the 'plugin.json' file for the plugin(s) you are running
+        grafana_image  : The grafana image you want to use (i.e. grafana/grafana-enterprise). Defaults to 'grafana/grafana'
         grafana_version: The image tag for the version of grafana you want to use. Defaults to 'latest'
         namespace      : The Kubernetes namespace to deploy to. Defaults to 'default'
         deps           : A list of Tilt resources Grafana should wait for
@@ -96,11 +97,11 @@ def grafana(context, plugin_files, grafana_version='latest', namespace='grafana'
 
     plugins = load_plugins(os.path.abspath(context), plugin_json_files)
     
-    # This is the docker image we are about to build
-    image_repository = "grafana/grafana"
+    # This is the Grafana docker image we are about to build
+    image_repository = grafana_image
     # TODO: Make this configurable
     image_tag = 'ops-devenv'
-    docker_build("%s:%s" % (image_repository, image_tag),
+    docker_build("%s:%s" % (image_repository, image_tag), 
                 dockerfile_contents = grafana_dockerfile_contents(context, plugins, grafana_version),
                 context             = context,
                 only                = [os.path.relpath(os.path.abspath( context + '/' + config.plugin_dist_dir), os.path.abspath(context))
@@ -130,7 +131,7 @@ def grafana(context, plugin_files, grafana_version='latest', namespace='grafana'
     chart_values['env'].update(extra_env)
 
     chart_values['image'] = {}
-    chart_values['image']['repository'] = image_repository
+    chart_values['image']['repository'] = image_repository 
     chart_values['image']['tag'] = image_tag
 
     # The assumption is that the Tiltfiles in the plugin repos will create the configmaps
@@ -176,7 +177,7 @@ def grafana(context, plugin_files, grafana_version='latest', namespace='grafana'
     # Deploy the chart
     helm_resource(
         'grafana',
-        'grafana/grafana',
+        image=image_respository,
         namespace=namespace,
         image_deps=[image_repository + ':' + image_tag],
         image_keys=[('image.registry', 'image.repository', 'image.tag')],

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -131,7 +131,7 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
     chart_values['env'].update(extra_env)
 
     chart_values['image'] = {}
-    chart_values['image']['repository'] = image_repository 
+    chart_values['image']['repository'] = image_repository
     chart_values['image']['tag'] = image_tag
 
     # The assumption is that the Tiltfiles in the plugin repos will create the configmaps

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -102,7 +102,7 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
     image_repository = grafana_image
     # TODO: Make this configurable
     image_tag = 'ops-devenv'
-    docker_build("%s:%s" % (image_repository, image_tag), 
+    docker_build("%s:%s" % (image_repository, image_tag),
                 dockerfile_contents = grafana_dockerfile_contents(context, plugins, grafana_image, grafana_version),
                 context             = context,
                 only                = [os.path.relpath(os.path.abspath( context + '/' + config.plugin_dist_dir), os.path.abspath(context))
@@ -138,7 +138,7 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
     chart_values['image']['repository'] = image_repository
     chart_values['image']['tag'] = image_tag
 
-    # Sets the Grafana Enterprise License
+    # Sets the Grafana Enterprise License Text
     chart_values['grafana.ini']['enterprise'] = {}
     chart_values['grafana.ini']['enterprise']['license_text'] = license
 

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -71,19 +71,27 @@ def get_or_create(dict, key):
         dict[key] = {}
     return dict[key]
 
+def update_grafana_ini(grafana_ini, extra_dict):
+    for k, v in extra_dict.items():
+        if type(v) == type({}):
+            grafana_ini[k] = update_grafana_ini(grafana_ini.get(k, {}), v)
+        else:
+            grafana_ini[k] = v
+    return grafana_ini
 
-def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version='latest', namespace='grafana', license='', deps=[], extra_env={}):
+
+def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_version='latest', namespace='grafana', deps=[], extra_env={}, extra_grafana_ini={}):
     """Deploys one or more plugin(s) in Grafana using the Helm Chart.
 
     Args:
-        context        : The Docker context directory that is the root of the Dockerfile. Typically the 'plugin' directory
-        plugin_files   : A path, or list of paths to the 'plugin.json' file for the plugin(s) you are running
-        grafana_image  : The grafana image you want to use. Defaults to 'grafana/grafana'
-        grafana_version: The image tag for the version of grafana you want to use. Defaults to 'latest'
-        namespace      : The Kubernetes namespace to deploy to. Defaults to 'default'
-        license        : The Grafana license key
-        deps           : A list of Tilt resources Grafana should wait for
-        extra_env      : A dict of env vars to pass to Grafana
+        context          : The Docker context directory that is the root of the Dockerfile. Typically the 'plugin' directory
+        plugin_files     : A path, or list of paths to the 'plugin.json' file for the plugin(s) you are running
+        grafana_image    : The grafana image you want to use. Defaults to 'grafana/grafana'
+        grafana_version  : The image tag for the version of grafana you want to use. Defaults to 'latest'
+        namespace        : The Kubernetes namespace to deploy to. Defaults to 'default'
+        deps             : A list of Tilt resources Grafana should wait for
+        extra_env        : A dict of env vars to pass to Grafana
+        extra_grafana_ini: A dict of key value pairs to configure the grafana.ini file
 
     Returns:
       Nothing
@@ -138,9 +146,11 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
     chart_values['image']['repository'] = image_repository
     chart_values['image']['tag'] = image_tag
 
-    # Sets the Grafana Enterprise License Text
-    chart_values['grafana.ini']['enterprise'] = {}
-    chart_values['grafana.ini']['enterprise']['license_text'] = license
+    # Sets the passed in additional Grafana_init fields
+    if len(extra_grafana_ini) > 0:
+        grafana_ini = chart_values["grafana.ini"] 
+        addtnl_grafana_ini = update_grafana_ini(grafana_ini, extra_grafana_ini)
+        chart_values["grafana.ini"].update(addtnl_grafana_ini)
 
     # The assumption is that the Tiltfiles in the plugin repos will create the configmaps
     # with the name <plugin_id>-provisioning

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -81,7 +81,7 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
         grafana_image  : The grafana image you want to use. Defaults to 'grafana/grafana'
         grafana_version: The image tag for the version of grafana you want to use. Defaults to 'latest'
         namespace      : The Kubernetes namespace to deploy to. Defaults to 'default'
-        license        : The Grafana license key. 
+        license        : The Grafana license key
         deps           : A list of Tilt resources Grafana should wait for
         extra_env      : A dict of env vars to pass to Grafana
 

--- a/grafana/grafana-values.yaml
+++ b/grafana/grafana-values.yaml
@@ -16,7 +16,7 @@ grafana.ini:
     enabled: true
     org_role: Admin
   feature_toggles:
-    enable: topnav
+    enable: topnav, accessControlOnCall
   log:
     level: info
   log.frontend:

--- a/grafana/grafana-values.yaml
+++ b/grafana/grafana-values.yaml
@@ -16,7 +16,7 @@ grafana.ini:
     enabled: true
     org_role: Admin
   feature_toggles:
-    enable: topnav, accessControlOnCall
+    enable: topnav
   log:
     level: info
   log.frontend:


### PR DESCRIPTION
Modifies Tilt Extension to:

- allow for the grafana image to be specified
- allow for the grafana license key to be passed in (needed for grafana-enterprise)
- enables the accessControlOnCall feature flag 

Fixes #11 