### PR TITLE
Disables the Grafana Helm chart's 'assertNoLeakedSecrets'

### DIFF
--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -115,6 +115,8 @@ def grafana(context, plugin_files, grafana_version='latest', namespace='grafana'
     k8s_yaml(secret_from_dict(name = 'grafana-admin-creds', 
                               namespace = namespace, 
                               inputs = {'admin-user': 'admin', 'admin-password':'admin'}))
+		# HACK: Add this value to allow unencrypted credentials. This is not recommended for production, and should be removed once we properly support variable expansion in this PR.
+		chart_values['assertNoLeakedSecrets'] = 'false'
     chart_values['admin'] = {}
     chart_values['admin']['existingSecret'] = 'grafana-admin-creds'
 

--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -115,8 +115,9 @@ def grafana(context, plugin_files, grafana_version='latest', namespace='grafana'
     k8s_yaml(secret_from_dict(name = 'grafana-admin-creds', 
                               namespace = namespace, 
                               inputs = {'admin-user': 'admin', 'admin-password':'admin'}))
-		# HACK: Add this value to allow unencrypted credentials. This is not recommended for production, and should be removed once we properly support variable expansion in this PR.
-		chart_values['assertNoLeakedSecrets'] = 'false'
+
+    # HACK: Add this value to allow unencrypted credentials. This is not recommended for production, and should be removed once we properly support variable expansion in this PR.
+    chart_values['assertNoLeakedSecrets'] = 'false'
     chart_values['admin'] = {}
     chart_values['admin']['existingSecret'] = 'grafana-admin-creds'
 


### PR DESCRIPTION
assertNoLeakedSecrets checks certain grafana.ini flags and makes sure they aren't rendered in plain text. This broke our extension, which renders them in plain text. We should fix this to properly avoid plain text, but for now we allow plain text "secrets" since this repo is meant for development only.