### PR TITLE
fix: Always mount service account token.

### DIFF
--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -112,18 +112,6 @@ def grafana(context, plugin_files, grafana_image='grafana/grafana', grafana_vers
                               namespace = namespace, 
                               inputs = {'admin-user': 'admin', 'admin-password':'admin'}))
 
-    # HACK: Add this value to allow unencrypted credentials. This is not recommended for production, and should be removed once we properly support variable expansion in this PR.
-    chart_values['assertNoLeakedSecrets'] = 'false'
-    chart_values['admin'] = {}
-    chart_values['admin']['existingSecret'] = 'grafana-admin-creds'
-
-    chart_values['serviceAccount'] = {}
-    chart_values['serviceAccount']['create'] = 'default'
-
-    chart_values['service'] = {}
-    chart_values['service']['port'] = '3000'
-    chart_values['service']['nodePort'] = '3000'
-
     # Set the env vars
     chart_values['env'] = {}
     chart_values['env'].update(extra_env)

--- a/grafana/grafana-values.yaml
+++ b/grafana/grafana-values.yaml
@@ -8,6 +8,22 @@ persistence:
 sidecar:
   datasources:
     enabled: true
+
+# HACK: Add this value to allow unencrypted credentials. This is not recommended for production, and should be removed once we properly support variable expansion in this PR.
+assertNoLeakedSecrets: false
+
+admin:
+  existingSecret: grafana-admin-creds
+serviceAccount:
+  # Broken by Helm chart version 7.3.2. Prefer to set this explicitly rather than depend on default behavior.
+  automountServiceAccountToken: true
+  create: default
+service:
+  port: 3000
+  nodePort: 3000
+
+
+
 grafana.ini:
   app_mode: development
   analytics:


### PR DESCRIPTION
Grafana's community helm chart changed the value of automountServiceAccountToken in version 7.3.2, which broke the datasources sidecar and anything else that uses a k8s service account default credentials.

See: https://github.com/grafana/helm-charts/issues/2986

This change explicitly sets automountServiceAccountToken to true. It also moves some constant values for the chart that were set in the Tiltfile into grafana-values.yaml with other constants. Dynamic values remain in the Tiltfile