### PR TITLE
fix: Use correct autoMount syntax

### DIFF
--- a/grafana/grafana-values.yaml
+++ b/grafana/grafana-values.yaml
@@ -16,7 +16,7 @@ admin:
   existingSecret: grafana-admin-creds
 serviceAccount:
   # Broken by Helm chart version 7.3.2. Prefer to set this explicitly rather than depend on default behavior.
-  automountServiceAccountToken: true
+  autoMount: true
   create: default
 service:
   port: 3000


### PR DESCRIPTION
I had used the value that ends up on the pod spec, not the syntax in the chart, in #17