### PR TITLE
Config map and subst changes

### DIFF
--- a/grafana/Tiltfile
+++ b/grafana/Tiltfile
@@ -76,6 +76,7 @@ def grafana(
     extra_env={},
     extra_grafana_ini={},
     additional_grafana_helm_chart_values_file=None,
+    extra_configmaps_mounts=[],
 ):
     """Deploys one or more plugin(s) in Grafana using the Helm Chart.
 
@@ -89,6 +90,7 @@ def grafana(
         extra_env                                 : A dict of env vars to pass to Grafana
         extra_grafana_ini                         : A dict of key value pairs to configure the grafana.ini file
         additional_grafana_helm_chart_values_file : Absolute path to a .yaml file which will be passed as an additional values file to the Grafana helm chart
+        extra_configmaps_mounts                 : A list of dicts of configmap mounts to add to the Grafana helm chart
 
     Returns:
       Nothing
@@ -117,6 +119,8 @@ def grafana(
     # which will be anything in the parent directory of this repo. To ensusure that the 'only' 
     # param is not empty add the default values file which should probably trigger a rebuild anyway.
     watched_files.append(default_grafana_values)
+
+    print("context: %s" % context)
     
     docker_build("%s:%s" % (image_repository, image_tag),
                 dockerfile_contents = grafana_dockerfile_contents(context, plugins, grafana_image, grafana_version),
@@ -145,27 +149,33 @@ def grafana(
         chart_values["grafana.ini"].update(extra_grafana_ini)
 
     # The assumption is that the Tiltfiles in the plugin repos will create the configmaps
-    # with the name <plugin_id>-provisioning
-    extraConfigmapsMounts = []
+    # with the name <plugin_id>-provisioning. If they don't, then we need to add them here.
+    if len(extra_configmaps_mounts) == 0:
+        extra_mounts = []
+        extra_mounts.extend(extra_configmaps_mounts)
+        for (_, plugin) in plugins.items():
+            plugin_id = plugin.plugin_id
+            # Tell the chart to mount it
+            extra_configmaps_mounts.append({
+                'name'     : '%s-provisioning' % plugin_id,
+                'mountPath': '/etc/grafana/provisioning/plugins/%s-provisioning.yaml' % plugin_id,
+                'subPath'  : '%s-provisioning.yaml' % plugin_id,
+                'configMap': '%s-provisioning' % plugin_id,
+                'readOnly' : 'true'
+            })
+        chart_values['extraConfigmapMounts'] = extra_mounts
+    else:
+        chart_values['extraConfigmapMounts'] = extra_configmaps_mounts
+
+    # Setup tracing for plugins that want it
     for (_, plugin) in plugins.items():
         plugin_id = plugin.plugin_id
-
-        # Tell the chart to mount it
-        extraConfigmapsMounts.append({
-            'name'     : '%s-provisioning' % plugin_id,
-            'mountPath': '/etc/grafana/provisioning/plugins/%s-provisioning.yaml' % plugin_id,
-            'subPath'  : '%s-provisioning.yaml' % plugin_id,
-            'configMap': '%s-provisioning' % plugin_id,
-            'readOnly' : 'true'
-        })
-
         # Tell the chart to enable tracing if the plugin wants it
         if plugin.enable_tracing:
           grafana_ini = chart_values['grafana.ini']
           plugin_values = get_or_create(grafana_ini, 'plugin.%s' % plugin_id)
           plugin_values['tracing'] = True
 
-    chart_values['extraConfigmapMounts'] = extraConfigmapsMounts
 
     # allow consumer of this tilt plugin to specify whatever additional helm values they'd like
     if additional_grafana_helm_chart_values_file:

--- a/var_subst/Tiltfile
+++ b/var_subst/Tiltfile
@@ -6,39 +6,62 @@ def var_subst(template, env):
         var_name = parts[0]
         default_val = parts[1] if len(parts) > 1 else None
         return (var_name, default_val)
-    
+
     start_idx = 0
     result = ""
     while start_idx < len(template):
-        # Find next "${"
-        open_idx = template.find("${", start_idx)
-        if open_idx == -1:
+        # Find next "$"
+        dollar_idx = template.find("$", start_idx)
+        if dollar_idx == -1:
             # If not found, append rest of template and break
             result += template[start_idx:]
             break
-        
-        # Append content before "${"
-        result += template[start_idx:open_idx]
-        
-        # Find closing "}"
-        close_idx = template.find("}", open_idx)
-        if close_idx == -1:
-            # Malformed pattern; append rest and break
-            result += template[open_idx:]
-            break
-        
-        # Extract content inside "${...}"
-        inner_content = template[open_idx + 2:close_idx]
-        var_name, default_val = extract_var_and_default(inner_content)
-        
-        # Use value from env if exists, otherwise use default value
-        value = os.environ.get(var_name, default_val)
-        if value == None:
-            value = ""  # If var doesn't exist and no default is provided
-        
-        result += value
-        
-        # Move on to next segment
-        start_idx = close_idx + 1
+
+        # Append content before "$"
+        result += template[start_idx:dollar_idx]
+
+        # Check if it's "${}" or "$VAR" format
+        if dollar_idx + 1 < len(template) and template[dollar_idx + 1] == "{":
+            # Handle ${VAR} or ${VAR:-default} format
+            open_idx = dollar_idx
+            close_idx = template.find("}", open_idx)
+            if close_idx == -1:
+                # Malformed pattern; append rest and break
+                result += template[open_idx:]
+                break
+
+            # Extract content inside "${...}"
+            inner_content = template[open_idx + 2:close_idx]
+            var_name, default_val = extract_var_and_default(inner_content)
+
+            # Use value from env if exists, otherwise use default value
+            value = env.get(var_name, default_val)
+            if value == None:
+                value = ""  # If var doesn't exist and no default is provided
+
+            result += value
+            start_idx = close_idx + 1
+        else:
+            # Handle $VAR format (no braces)
+            var_start = dollar_idx + 1
+            var_end = var_start
+
+            # Check if the first character is a valid variable name start (letter or underscore)
+            if var_start < len(template) and (template[var_start].isalpha() or template[var_start] == "_"):
+                # Find the end of the variable name (alphanumeric and underscore)
+                while var_end < len(template) and (template[var_end].isalnum() or template[var_end] == "_"):
+                    var_end += 1
+
+                # Extract variable name
+                var_name = template[var_start:var_end]
+
+                # Use value from env if exists, otherwise empty string
+                value = env.get(var_name, "")
+                result += value
+                start_idx = var_end
+            else:
+                # Not a valid variable name (like $100), just append the $ and continue
+                result += "$"
+                start_idx = dollar_idx + 1
 
     return result

--- a/var_subst/test/Tiltfile
+++ b/var_subst/test/Tiltfile
@@ -38,12 +38,54 @@ def test_substitute_with_malformed_pattern():
     result = var_subst(template, env)
     assert_equals(result, "Hello, ${FOO!")
 
+def test_substitute_simple_var_existing():
+    env = {"FOO": "SomeValue"}
+    template = "Hello, $FOO!"
+    result = var_subst(template, env)
+    assert_equals(result, "Hello, SomeValue!")
+
+def test_substitute_simple_var_missing():
+    env = {}
+    template = "Hello, $FOO!"
+    result = var_subst(template, env)
+    assert_equals(result, "Hello, !")
+
+def test_substitute_simple_var_with_underscore():
+    env = {"FOO_BAR": "TestValue"}
+    template = "Hello, $FOO_BAR!"
+    result = var_subst(template, env)
+    assert_equals(result, "Hello, TestValue!")
+
+def test_substitute_simple_var_with_numbers():
+    env = {"FOO123": "NumericValue"}
+    template = "Hello, $FOO123!"
+    result = var_subst(template, env)
+    assert_equals(result, "Hello, NumericValue!")
+
+def test_substitute_dollar_without_var():
+    env = {}
+    template = "Price: $100"
+    result = var_subst(template, env)
+    assert_equals(result, "Price: $100")
+
+def test_substitute_mixed_formats():
+    env = {"FOO": "Simple", "BAR": "Braced"}
+    template = "Mix: $FOO and ${BAR:-default}"
+    result = var_subst(template, env)
+    assert_equals(result, "Mix: Simple and Braced")
+
 def run_tests():
     test_substitute_with_existing_var()
     test_substitute_with_missing_var_no_default()
     test_substitute_with_missing_var_with_default()
     test_substitute_with_existing_var_and_default()
     test_substitute_with_malformed_pattern()
+    test_substitute_simple_var_existing()
+    test_substitute_simple_var_missing()
+    test_substitute_simple_var_with_underscore()
+    test_substitute_simple_var_with_numbers()
+    test_substitute_dollar_without_var()
+    test_substitute_mixed_formats()
     print("All tests passed!")
 
 # Running the tests


### PR DESCRIPTION

    Currently, the grafana plugin would assume that a configMap
    for the plugin provisioning, it was already created and created the config
    for the helm char for this config map.

    If you want to do datasource provisioning, then is makes sense
    for the plugin Tiltfile to manage this, as this extension does not
    know about them.

    If the plugin chooses to manage both the CM and the helm config,
    then it must do so for all provisioning.

Also, teach `var_subst` to substitute on `$VAR` in additon to `${VAR}`
